### PR TITLE
Add ability to instrument via StatsD

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ If you want to change that, you can tell `rack-timer` to send data to another
 file-y object, for instance:
 
     RackTimer.output = $stdout
-    
+
+If you want to send execution time to StatsD as well, you can specify a client:
+
+    RackTimer.statsd = $statsd
 
 ## Usage
 


### PR DESCRIPTION
This allows for an optional statsd client to be passed into RackTimer,
which will receive the timings for individual middlewares
